### PR TITLE
Email activation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ In case you are using Kirby´s Plainkit ensure to add the pages/links for the fo
 - Logout
 - User 
 
-> Last Login have been removed since hooks make the life more difficult.
+> Last Login have been removed since hooks make life more difficult.
 
-The user will be logged in even the account is not activated by email! 
+The user will be logged in even the account is not activated by email yet! 
 You can check `$kirby->user()->emailActivation()` for disabling certain features, pages etc.
 
 To change the email template go to `templates\email\account-activation.*.php`.
+
+In case the user changes the email adress teh activation status is set to `false`and another email will be sent.
 
 ### Kirby CMS Licence 
 **Kirby CMS requires a dedicated licence:**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A functional, lean, and unstyled Kirby User Management Add-On (Pre-Release) for 
 
 **Functionality** | **Comment**
 ---- | ----
-Register / Login| Yes (Log last Login)
+Register / Login| Yes
+Activation by Email | Yes (Not by dafault)
 Logout | Virtual
 Change Email | Yep
 Change Password | Sure
@@ -36,8 +37,15 @@ Also this kind of Add-On adapts way more easy to **YOUR** project.
 1. Paste (overwrite) the folder *content* and *site* on top of the root folder of your Kirby installation.
 1. Done!
 
+### Configuration
+- Set `email` config (see [Kirby email options](https://getkirby.com/docs/reference/system/options/email))
+- Set `user.email.activation` config to true (default false).
+- Set `user.email.activation.sender` config email sender (mandatory when email activation is enabled).
+- Set `user.email.activation.subject` config email subject (mandatory when email activation is enabled).
+- Change activation token length in `register.php` controller (default 12).
+
 ## Notes:
-This Add-On is built for Kirby CMS based on **Kirby´s Starterkit Version 3.5.0**. 
+This Add-On is built for Kirby CMS based on **Kirby´s Starterkit Version 3.5.7.1**. 
 
 In case you are using Kirby´s Plainkit ensure to add the pages/links for the following pages somewhere in your snippets or templates!
 
@@ -45,6 +53,13 @@ In case you are using Kirby´s Plainkit ensure to add the pages/links for the fo
 - Login
 - Logout
 - User 
+
+> Last Login have been removed since hooks make the life more difficult.
+
+The user will be logged in even the account is not activated by email! 
+You can check `$kirby->user()->emailActivation()` for disabling certain features, pages etc.
+
+To change the email template go to `templates\email\account-activation.*.php`.
 
 ### Kirby CMS Licence 
 **Kirby CMS requires a dedicated licence:**

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -12,7 +12,7 @@ return [
   'panel' =>[
     'install' => true
   ],
-  'user.email.activation' => false,
+  'user.email.activation' => true,
   'user.email.activation.sender' => '...',
   'user.email.activation.subject' => 'Account Activation Link',
   'routes' => [
@@ -29,15 +29,19 @@ return [
       }
     ],
     [
-      'pattern' => 'user/activate/(:all)/(:alphanum)',
-      'action'  => function($email, $token) {
+      'pattern' => 'user/activate/(:alphanum)',
+      'action'  => function($token) {
 
-        $kirby   = kirby();
+        if (option('user.email.activation', false) === false) {
+          go();
+        }
+
+        $kirby = kirby();
         $kirby->impersonate('kirby');
 
-        if ($user = $kirby->user($email)) {
+        if ($user = $kirby->users()->findBy('emailActivationToken', $token)) {
 
-          if ($user->emailActivation()->toString() === Str::toType($token, 'string')) {
+          if ($user->emailActivationToken()->toString() === Str::toType($token, 'string')) {
 
             $user->update([
               'emailActivation' => true
@@ -50,6 +54,7 @@ return [
           else {
             return false;
             //go('CUSTOM_ERROR_ACTIVATION_PAGE');
+            //return page('CUSTOM_ERROR_ACTIVATION_PAGE');
           }
           
         }
@@ -66,7 +71,7 @@ return [
       'security' => 'tls',
       'auth' => true,
       'username' => '...',
-      'password' => '...'
+      'password' => '..'
     ]
   ]
 ];

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -12,6 +12,7 @@ return [
   'panel' =>[
     'install' => true
   ],
+  'user.email.activation' => false,
   'hooks' => [
     'user.login:after' => function ($user, $session) {
       $user->update([

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -13,13 +13,8 @@ return [
     'install' => true
   ],
   'user.email.activation' => false,
-  'hooks' => [
-    'user.login:after' => function ($user, $session) {
-      $user->update([
-        'lastLogin' => date("d.m.Y")
-      ]);
-    }
-  ],
+  'user.email.activation.sender' => '...',
+  'user.email.activation.subject' => 'Account Activation Link',
   'routes' => [
     [
       'pattern' => 'logout',
@@ -32,6 +27,46 @@ return [
         go('login');
 
       }
+    ],
+    [
+      'pattern' => 'user/activate/(:all)/(:alphanum)',
+      'action'  => function($email, $token) {
+
+        $kirby   = kirby();
+        $kirby->impersonate('kirby');
+
+        if ($user = $kirby->user($email)) {
+
+          if ($user->emailActivation()->toString() === Str::toType($token, 'string')) {
+
+            $user->update([
+              'emailActivation' => true
+            ]);
+
+            go();
+            //go('CUSTOM_SUCCESSFUL_ACTIVATION_PAGE');
+
+          }
+          else {
+            return false;
+            //go('CUSTOM_ERROR_ACTIVATION_PAGE');
+          }
+          
+        }
+
+        $kirby->impersonate(); 
+      }
+    ]
+  ],
+  'email' => [
+    'transport' => [
+      'type' => 'smtp',
+      'host' => '...',
+      'port' => 587,
+      'security' => 'tls',
+      'auth' => true,
+      'username' => '...',
+      'password' => '...'
     ]
   ]
 ];

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -16,7 +16,7 @@ return [
   'hooks' => [
     'user.login:after' => function ($user, $session) {
       $user->update([
-        'lastLogin' => date("m.d.Y")
+        'lastLogin' => date("d.m.Y")
       ]);
     }
   ],

--- a/site/controllers/register.php
+++ b/site/controllers/register.php
@@ -10,7 +10,7 @@ return function ($kirby) {
   $alert = null;
 
   // TOKEN FOR ACCOUNT ACTIVATION
-  $token = Str::random(12);
+  $token = Str::random(16);
 
 	if($kirby->request()->is('post') && get('register')) {
 
@@ -55,7 +55,8 @@ return function ($kirby) {
         if (option('user.email.activation', false) === true) {
           
           $user->update([
-            'emailActivation' => $token
+            'emailActivation'       => false,
+            'emailActivationToken'  => $token
           ]);
         }
 
@@ -79,7 +80,7 @@ return function ($kirby) {
         // ACTIVATE ACCOUNT BY EMAIL IF ENABLED
         if (option('user.email.activation', false) === true) {
 
-          $link = $kirby->site()->url() . "/user/activate/" . $data['email'] . "/" . $token;
+          $link = $kirby->site()->url() . "/user/activate/" . $token;
 
           $email = $kirby->email([
             'to'       => $data['email'],

--- a/site/controllers/register.php
+++ b/site/controllers/register.php
@@ -9,6 +9,9 @@ return function ($kirby) {
   $error = null;
   $alert = null;
 
+  // TOKEN FOR ACCOUNT ACTIVATION
+  $token = Str::random(12);
+
 	if($kirby->request()->is('post') && get('register')) {
 
     $data = [
@@ -42,11 +45,19 @@ return function ($kirby) {
 
         // CREATE USER
         $user = $kirby->users()->create([
-          'email'     => $data['email'],
-          'role'      => 'user',
-          'language'  => 'en',
-          'password'  => $data['password']
+          'email'             => $data['email'],
+          'role'              => 'user',
+          'language'          => 'en',
+          'password'          => $data['password']
         ]);
+
+        // CHECK EMAIL ACTIVATION
+        if (option('user.email.activation', false) === true) {
+          
+          $user->update([
+            'emailActivation' => $token
+          ]);
+        }
 
         $kirby->impersonate(); 
 
@@ -63,13 +74,29 @@ return function ($kirby) {
       }
 
       // SUCCESSFUL
-      if (empty($alert) === true) {
+      if (empty($alert) === true && $user) {
+
+        // ACTIVATE ACCOUNT BY EMAIL IF ENABLED
+        if (option('user.email.activation', false) === true) {
+
+          $link = $kirby->site()->url() . "/user/activate/" . $data['email'] . "/" . $token;
+
+          $email = $kirby->email([
+            'to'       => $data['email'],
+            'from'     => option('user.email.activation.sender'),
+            'subject'  => option('user.email.activation.sender', 'Account Activation Link'),
+            'template' => 'account-activation',
+            'data'     => [
+              'link'   => $link,
+            ]
+          ]);
+        }
 
         // LOGIN USER
-        if($user and $user->login($data['password'])) {
+        if($user->login($data['password'])) {
           go();
-        }  
-
+        } 
+               
         $data = [];
       }
     }

--- a/site/controllers/user.php
+++ b/site/controllers/user.php
@@ -50,14 +50,18 @@ return function ($kirby, $page) {
           $kirby->user()->changeEmail($data['email']);
           $success = 'Your email has been changed!';
 
+          // TOKEN FOR ACCOUNT RE-ACTIVATION
+          $token = Str::random(16);
+
           $kirby->user()->update([
-            'emailActivation' => false
+            'emailActivation'       => false,
+            'emailActivationToken'  => $token
           ]);
 
           // ACTIVATE ACCOUNT BY EMAIL IF ENABLED
           if (option('user.email.activation', false) === true) {
 
-            $link = $kirby->site()->url() . "/user/activate/" . $kirby->user()->emailActivationToken()->toString();
+            $link = $kirby->site()->url() . "/user/activate/" . $token;
 
             $email = $kirby->email([
               'to'       => $data['email'],

--- a/site/controllers/user.php
+++ b/site/controllers/user.php
@@ -9,6 +9,12 @@ return function ($kirby, $page) {
   $error = null;
   $alert = null;
 
+  // CHECK ACCOUNT ACTIVATION
+  if(filter_var($kirby->user()->emailActivation(), FILTER_VALIDATE_BOOLEAN) != true) {
+
+    $alert['error'] = 'Please check your emails to activate the account.';
+  }
+
   // UPDATE USER
   if($kirby->request()->is('post') && get('update')) {
 

--- a/site/templates/emails/account-activation.html.php
+++ b/site/templates/emails/account-activation.html.php
@@ -1,0 +1,2 @@
+<h1>Welcome</h1>
+<p>Please click the link to activate your Account: <a href="<?= $link ?>"><?= $link ?></a></p>

--- a/site/templates/emails/account-activation.text.php
+++ b/site/templates/emails/account-activation.text.php
@@ -1,0 +1,3 @@
+Welcome,
+
+Please click the link to activate your Account: <?= $link ?>


### PR DESCRIPTION
- Disabled by default
- requires [email transport setup ](https://getkirby.com/docs/reference/system/options/email#email-transport)
- Changing email resets email activation